### PR TITLE
Fix references in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,11 +2,13 @@
 
 This repository provides documentation and examples for the `system_maint.sh` script. The instructions below apply to all contributions.
 
+The repository does not contain the `system_maint.sh` script itself; use these files as a reference for your own copy.
+
 ## Documentation Layout
 
-- `AGENTS_CI.md.txt` &ndash; explains how ShellCheck and GitHub Actions lint the script.
-- `AGENTS_SYSTEM.md.txt` &ndash; lists required system utilities.
-- `AGENTS_SECURITY.md.txt` &ndash; describes security and backup tools.
+- `AGENTS_CI.md` &ndash; explains how ShellCheck and GitHub Actions lint the script.
+- `AGENTS_SYSTEM.md` &ndash; lists required system utilities.
+- `AGENTS_SECURITY.md` &ndash; describes security and backup tools.
 
 Refer to these files if you need details about dependencies or CI features.
 


### PR DESCRIPTION
## Summary
- add note that the repo doesn't include the `system_maint.sh` script

## Testing
- `shellcheck` *(skipped: `system_maint.sh` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68404f373304832f89c08b295287423c