### PR TITLE
Remove script-specific references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,8 @@
 # AGENTS Repository Guide
 
-This repository provides documentation and examples for the `system_maint.sh` script. The instructions below apply to all contributions.
+This repository provides documentation and examples for system maintenance tasks. The instructions below apply to all contributions.
 
-The repository does not contain the `system_maint.sh` script itself; use these files as a reference for your own copy.
+The repository does not contain a specific maintenance script; use these files as a reference for your own solution.
 
 ## Documentation Layout
 
@@ -17,7 +17,7 @@ Refer to these files if you need details about dependencies or CI features.
 1. **Create small commits** using present‑tense summaries (e.g. `Add root AGENTS guide`).
 2. **Include a brief body** if the commit needs more context.
 3. **Run relevant checks** before committing:
-   - If `system_maint.sh` exists, execute `shellcheck system_maint.sh`.
+   - If you maintain a shell script, execute `shellcheck` on it.
 4. **Open a Pull Request** summarising what changed and what checks were run.
 
 ## Pull Request Body

--- a/AGENTS_CI.md
+++ b/AGENTS_CI.md
@@ -2,7 +2,7 @@
 
 > **Shell Script Linting & Continuous Integration**  
 > _This file documents the use of ShellCheck for linting and GitHub Actions for
-automated validation of `system_maint.sh`._
+automated validation of maintenance scripts._
 
 ---
 
@@ -12,14 +12,14 @@ automated validation of `system_maint.sh`._
   A static analysis tool for shell scripts. It identifies syntax errors,
   stylistic issues, and unsafe practices in POSIX/Bash scripts.
   _Used to ensure the long-term maintainability and security of
-  `system_maint.sh`._
+  maintenance scripts._
 
 ### Usage
 
 To manually check your script:
 
 ```bash
-shellcheck system_maint.sh
+shellcheck <your_script.sh>
 ```
 
 ---

--- a/AGENTS_SECURITY.md
+++ b/AGENTS_SECURITY.md
@@ -1,8 +1,8 @@
 # AGENTS_SECURITY.md
 
 > **Security & Backup Agents**  
-> _This file documents the tools used by `system_maint.sh` for vulnerability
-scanning, rootkit detection, firewall auditing, and backup operations._
+> _This file documents the tools available for vulnerability scanning,
+rootkit detection, firewall auditing, and backup operations._
 
 ---
 

--- a/AGENTS_SYSTEM.md
+++ b/AGENTS_SYSTEM.md
@@ -1,9 +1,8 @@
 # AGENTS_SYSTEM.md
 
-> **System Maintenance Agents**  
-> _This file documents the system-level agents used by the `system_maint.sh`
-script to manage core functionality such as packages, storage, system
-monitoring, and cleanup._
+> **System Maintenance Agents**
+> _This file documents the system-level tools used to manage core
+functionality such as packages, storage, system monitoring, and cleanup._
 
 ---
 
@@ -87,8 +86,7 @@ monitoring, and cleanup._
 
 ## Notes
 
-- These agents are considered **essential** for the baseline operation of
-  `system_maint.sh`.
+- These agents are considered **essential** for baseline operation.
 - The script attempts to detect and use each tool. If a tool is missing and
   required, it will prompt for installation or skip the related functionality.
 


### PR DESCRIPTION
## Summary
- edit AGENTS instructions to remove mentions of `system_maint.sh`
- keep shellcheck guidance but generalize for any script

## Testing
- `markdownlint -V` *(fails: command not found)*
- `shellcheck system_maint.sh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68418275a080832f94d62e3619f5e36e