### PR TITLE
Refine AGENTS docs for Arch Linux

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,12 +1,13 @@
 # AGENTS Repository Guide
 
-This repository provides documentation and examples for system maintenance tasks. The instructions below apply to all contributions.
+This repository provides documentation for Arch Linux maintenance tasks.
+The instructions below apply to all contributions.
 
-The repository does not contain a specific maintenance script; use these files as a reference for your own solution.
+There is no included script; adapt these notes to fit your workflow.
 
 ## Documentation Layout
 
-- `AGENTS_CI.md` &ndash; explains how ShellCheck and GitHub Actions lint the script.
+- `AGENTS_CI.md` &ndash; shows how ShellCheck and GitHub Actions lint scripts.
 - `AGENTS_SYSTEM.md` &ndash; lists required system utilities.
 - `AGENTS_SECURITY.md` &ndash; describes security and backup tools.
 
@@ -14,11 +15,11 @@ Refer to these files if you need details about dependencies or CI features.
 
 ## Contribution Workflow
 
-1. **Create small commits** using present‑tense summaries (e.g. `Add root AGENTS guide`).
+1. **Create small commits** in present tense (e.g. `Add root AGENTS guide`).
 2. **Include a brief body** if the commit needs more context.
 3. **Run relevant checks** before committing:
    - If you maintain a shell script, execute `shellcheck` on it.
-4. **Open a Pull Request** summarising what changed and what checks were run.
+4. **Open a Pull Request** summarizing what changed and which checks ran.
 
 ## Pull Request Body
 
@@ -28,4 +29,5 @@ Refer to these files if you need details about dependencies or CI features.
 
 ---
 
-This `AGENTS.md` is the entry point for instructions. Other AGENTS files provide additional context.
+This `AGENTS.md` is the entry point for instructions.
+Other AGENTS files provide additional context.

--- a/AGENTS_CI.md
+++ b/AGENTS_CI.md
@@ -2,7 +2,7 @@
 
 > **Shell Script Linting & Continuous Integration**  
 > _This file documents the use of ShellCheck for linting and GitHub Actions for
-automated validation of maintenance scripts._
+automated validation of shell scripts._
 
 ---
 
@@ -11,8 +11,7 @@ automated validation of maintenance scripts._
 - **`shellcheck`**  
   A static analysis tool for shell scripts. It identifies syntax errors,
   stylistic issues, and unsafe practices in POSIX/Bash scripts.
-  _Used to ensure the long-term maintainability and security of
-  maintenance scripts._
+  _Used to ensure the long-term maintainability and security._
 
 ### Usage
 

--- a/AGENTS_SECURITY.md
+++ b/AGENTS_SECURITY.md
@@ -39,7 +39,7 @@ rootkit detection, firewall auditing, and backup operations._
 - **`rsync`**  
   Performs a full incremental backup of the root filesystem to a specified
   directory.
-  _Optional and manually triggered during script execution._
+  _Optional and manually triggered._
 
 ---
 
@@ -47,7 +47,7 @@ rootkit detection, firewall auditing, and backup operations._
 
 - **`gamemode`**  
   A runtime daemon that optimizes the system for gaming workloads.  
-  _The script checks its status if installed._
+  Check its status if installed.
 
 - **`nvidia-utils`**  
   Enables `nvidia-smi` for querying NVIDIA GPU status and temperatures.  
@@ -58,7 +58,7 @@ rootkit detection, firewall auditing, and backup operations._
 ## Notes
 
 - All security-related tools are **optional but recommended**.
-- If a tool is not installed, the script prompts the user to install or skip it.
+- If a tool is not installed, you can choose to install or skip it.
 - Skipping an agent disables its corresponding feature gracefully.
 - Backups (via Timeshift, Snapper, or rsync) are triggered early to ensure
   recovery is possible.

--- a/AGENTS_SYSTEM.md
+++ b/AGENTS_SYSTEM.md
@@ -40,7 +40,7 @@ functionality such as packages, storage, system monitoring, and cleanup._
 ## 🌐 Platform Tools
 
 - **`flatpak`**  
-  Enables support for Flatpak applications. The script uses it to update
+  Enables support for Flatpak applications. Use it to update
   Flatpak-managed apps if installed.
 
 ---
@@ -68,7 +68,7 @@ functionality such as packages, storage, system monitoring, and cleanup._
   critical error messages.
 
 - **`systemctl`**  
-  Core systemd utility for managing system services. The script checks for
+  Core systemd utility for managing system services. Check for
   failed services.
 
 ---
@@ -87,7 +87,7 @@ functionality such as packages, storage, system monitoring, and cleanup._
 ## Notes
 
 - These agents are considered **essential** for baseline operation.
-- The script attempts to detect and use each tool. If a tool is missing and
-  required, it will prompt for installation or skip the related functionality.
+- You can detect and use each tool.
+  If a tool is missing and required, you may prompt for installation or skip it.
 
 ---

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # AGENTS.md-upgrade-proj
 
-This repository demonstrates how to organize AGENTS documentation.
+This repository contains AGENTS documentation for Arch Linux.
 See `AGENTS.md` for contribution guidelines and references to the
 other AGENTS files.


### PR DESCRIPTION
## Summary
- clarify AGENTS intro for Arch Linux and remove template wording
- drop references to non-existent scripts in CI and security docs
- rewrite README intro

## Testing
- `npx markdownlint-cli2 '**/*.md' '#node_modules'`
- `proselint AGENTS_*.md`
- `yamllint -d .yamllint.yml .github/workflows/*.yml`


------
https://chatgpt.com/codex/tasks/task_e_68418cfcd410832fb6406aca593ddb1d